### PR TITLE
Improve DBC frame format, add TX node

### DIFF
--- a/FoxESS_v1_15.dbc
+++ b/FoxESS_v1_15.dbc
@@ -399,7 +399,7 @@ BO_ 2147486725 Pack_1: 8 FoxESS_battery
  SG_ Pack_SoC : 32|8@1+ (1,0) [0|1] "%"  FoxESS_battery
  SG_ Pack_Volts : 48|16@1+ (0.001,0) [0|1] "V"  FoxESS_battery
 
-BO_ 2147484678 Pack_2: 8 FoxESS_battery
+BO_ 2147486726 Pack_2: 8 FoxESS_battery
  SG_ current_sensor : 0|16@1- (0.1,0) [0|1] "A"  FoxESS_battery
  SG_ Pack_Temp_Avg_Hi : 16|8@1+ (1,-50) [0|60] "C"  FoxESS_battery
  SG_ Pack_Temp_Avg_Lo : 24|8@1+ (1,-50) [0|60] "C"  FoxESS_battery

--- a/FoxESS_v1_15.dbc
+++ b/FoxESS_v1_15.dbc
@@ -33,481 +33,480 @@ NS_ :
 
 BS_:
 
-BU_: FoxESS_inverter
-
-
-BO_ 3101 BMS_CellVolts_x1: 8 FoxESS_inverter
- SG_ cell_1_volts : 0|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
- SG_ cell_2_volts : 16|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
- SG_ cell_3_volts : 32|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
- SG_ cell_4_volts : 48|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
-
-BO_ 3105 BMS_CellVolts_x4: 8 FoxESS_inverter
- SG_ cell_5_volts : 0|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
- SG_ cell_6_volts : 16|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
- SG_ cell_7_volts : 32|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
- SG_ cell_8_volts : 48|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
-
-BO_ 3109 BMS_CellVolts_x8: 8 FoxESS_inverter
- SG_ cell_9_volts : 0|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
- SG_ cell_10_volts : 16|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
- SG_ cell_11_volts : 32|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
- SG_ cell_12_volts : 48|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
-
-BO_ 3113 BMS_CellVoltsx12: 8 FoxESS_inverter
- SG_ cell_13_volts : 0|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
- SG_ cell_14_volts : 16|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
- SG_ cell_15_volts : 32|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
- SG_ cell_16_volts : 48|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
-
-BO_ 3117 BMS_CellVolts5: 8 FoxESS_inverter
- SG_ cell_17_volts : 0|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
- SG_ cell_18_volts : 16|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
- SG_ cell_19_volts : 32|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
- SG_ cell_20_volts : 48|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
-
-BO_ 3121 BMS_CellVolts6: 8 FoxESS_inverter
- SG_ cell_21_volts : 0|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
- SG_ cell_22_volts : 16|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
- SG_ cell_23_volts : 32|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
- SG_ cell_24_volts : 48|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
-
-BO_ 3125 BMS_CellVolts7: 8 FoxESS_inverter
- SG_ cell_25_volts : 0|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
- SG_ cell_26_volts : 16|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
- SG_ cell_27_volts : 32|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
- SG_ cell_28_volts : 48|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
-
-BO_ 3129 BMS_CellVolts8: 8 FoxESS_inverter
- SG_ cell_29_volts : 0|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
- SG_ cell_30_volts : 16|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
- SG_ cell_31_volts : 32|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
- SG_ cell_32_volts : 48|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
-
-BO_ 3133 BMS_CellVolts9: 8 FoxESS_inverter
- SG_ cell_33_volts : 0|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
- SG_ cell_34_volts : 16|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
- SG_ cell_35_volts : 32|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
- SG_ cell_36_volts : 48|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
-
-BO_ 3137 BMS_CellVolts10: 8 FoxESS_inverter
- SG_ cell_37_volts : 0|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
- SG_ cell_38_volts : 16|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
- SG_ cell_39_volts : 32|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
- SG_ cell_40_volts : 48|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
-
-BO_ 3141 BMS_CellVolts11: 8 FoxESS_inverter
- SG_ cell_41_volts : 0|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
- SG_ cell_42_volts : 16|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
- SG_ cell_43_volts : 32|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
- SG_ cell_44_volts : 48|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
-
-BO_ 3145 BMS_CellVolts12: 8 FoxESS_inverter
- SG_ cell_45_volts : 0|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
- SG_ cell_46_volts : 16|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
- SG_ cell_47_volts : 32|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
- SG_ cell_48_volts : 48|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
-
-BO_ 3149 BMS_CellVolts13: 8 FoxESS_inverter
- SG_ cell_49_volts : 0|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
- SG_ cell_50_volts : 16|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
- SG_ cell_51_volts : 32|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
- SG_ cell_52_volts : 48|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
-
-BO_ 3153 BMS_CellVolts14: 8 FoxESS_inverter
- SG_ cell_53_volts : 0|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
- SG_ cell_54_volts : 16|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
- SG_ cell_55_volts : 32|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
- SG_ cell_56_volts : 48|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
-
-BO_ 3157 BMS_CellVolts15: 8 FoxESS_inverter
- SG_ cell_57_volts : 0|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
- SG_ cell_58_volts : 16|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
- SG_ cell_59_volts : 32|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
- SG_ cell_60_volts : 48|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
-
-BO_ 3161 BMS_CellVolts16: 8 FoxESS_inverter
- SG_ cell_61_volts : 0|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
- SG_ cell_62_volts : 16|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
- SG_ cell_63_volts : 32|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
- SG_ cell_64_volts : 48|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
-
-BO_ 3165 BMS_CellVolts17: 8 FoxESS_inverter
- SG_ cell65_volts : 0|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
- SG_ cell66_volts : 16|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
- SG_ cell67_volts : 32|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
- SG_ cell68_volts : 48|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
-
-BO_ 3169 BMS_CellVolts18: 8 FoxESS_inverter
- SG_ cell69_volts : 0|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
- SG_ cell70_volts : 16|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
- SG_ cell71_volts : 32|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
- SG_ cell72_volts : 48|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
-
-BO_ 3173 BMS_CellVolts19: 8 FoxESS_inverter
- SG_ cell73_volts : 0|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
- SG_ cell74_volts : 16|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
- SG_ cell75_volts : 32|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
- SG_ cell76_volts : 48|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
-
-BO_ 3177 BMS_CellVolts20: 8 FoxESS_inverter
- SG_ cell77_volts : 0|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
- SG_ cell78_volts : 16|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
- SG_ cell79_volts : 32|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
- SG_ cell80_volts : 48|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
-
-BO_ 3181 BMS_CellVolts21: 8 FoxESS_inverter
- SG_ cell81_volts : 0|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
- SG_ cell82_volts : 16|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
- SG_ cell83_volts : 32|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
- SG_ cell84_volts : 48|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
-
-BO_ 3185 BMS_CellVolts22: 8 FoxESS_inverter
- SG_ cell85_volts : 0|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
- SG_ cell86_volts : 16|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
- SG_ cell87_volts : 32|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
- SG_ cell88_volts : 48|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
-
-BO_ 3189 BMS_CellVolts23: 8 FoxESS_inverter
- SG_ cell89_volts : 0|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
- SG_ cell90_volts : 16|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
- SG_ cell91_volts : 32|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
- SG_ cell92_volts : 48|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
-
-BO_ 3193 BMS_CellVolts24: 8 FoxESS_inverter
- SG_ cell93_volts : 0|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
- SG_ cell94_volts : 16|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
- SG_ cell95_volts : 32|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
- SG_ cell96_volts : 48|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
-
-BO_ 3197 BMS_CellVolts25: 8 FoxESS_inverter
- SG_ cell97_volts : 0|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
- SG_ cell98_volts : 16|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
- SG_ cell99_volts : 32|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
- SG_ cell100_volts : 48|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
-
-BO_ 3201 BMS_CellVolts26: 8 FoxESS_inverter
- SG_ cell101_volts : 0|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
- SG_ cell102_volts : 16|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
- SG_ cell103_volts : 32|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
- SG_ cell104_volts : 48|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
-
-BO_ 3205 BMS_CellVolts27: 8 FoxESS_inverter
- SG_ cell105_volts : 0|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
- SG_ cell106_volts : 16|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
- SG_ cell107_volts : 32|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
- SG_ cell108_volts : 48|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
-
-BO_ 3209 BMS_CellVolts28: 8 FoxESS_inverter
- SG_ cell109_volts : 0|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
- SG_ cell110_volts : 16|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
- SG_ cell111_volts : 32|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
- SG_ cell112_volts : 48|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
-
-BO_ 3213 BMS_CellVolts29: 8 FoxESS_inverter
- SG_ cell113_volts : 0|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
- SG_ cell114_volts : 16|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
- SG_ cell115_volts : 32|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
- SG_ cell116_volts : 48|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
-
-BO_ 3217 BMS_CellVolts30: 8 FoxESS_inverter
- SG_ cell117_volts : 0|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
- SG_ cell118_volts : 16|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
- SG_ cell119_volts : 32|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
- SG_ cell120_volts : 48|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
-
-BO_ 3221 BMS_CellVolts31: 8 FoxESS_inverter
- SG_ cell121_volts : 0|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
- SG_ cell122_volts : 16|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
- SG_ cell123_volts : 32|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
- SG_ cell124_volts : 48|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
-
-BO_ 3225 BMS_CellVolts31: 8 FoxESS_inverter
- SG_ cell125_volts : 0|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
- SG_ cell126_volts : 16|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
- SG_ cell127_volts : 32|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
- SG_ cell128_volts : 48|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
-
-BO_ 3229 BMS_CellVolts31: 8 FoxESS_inverter
- SG_ cell129_volts : 0|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
- SG_ cell130_volts : 16|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
- SG_ cell131_volts : 32|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
- SG_ cell132_volts : 48|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
-
-BO_ 3233 BMS_CellVolts31: 8 FoxESS_inverter
- SG_ cell133_volts : 0|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
- SG_ cell134_volts : 16|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
- SG_ cell135_volts : 32|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
- SG_ cell136_volts : 48|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
-
-BO_ 3237 BMS_CellVolts31: 8 FoxESS_inverter
- SG_ cell137_volts : 0|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
- SG_ cell138_volts : 16|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
- SG_ cell139_volts : 32|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
- SG_ cell140_volts : 48|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
-
-BO_ 3241 BMS_CellVolts31: 8 FoxESS_inverter
- SG_ cell141_volts : 0|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
- SG_ cell142_volts : 16|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
- SG_ cell143_volts : 32|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
- SG_ cell144_volts : 48|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
-
-BO_ 6257 Inverter_Request: 8 FoxESS_inverter
- SG_ Rqst_0 : 0|8@1+ (1,0) [0|256] ""  FoxESS_inverter
- SG_ Rqst_2 : 16|8@1+ (1,0) [0|256] ""  FoxESS_inverter
- SG_ Rqst_4 : 32|8@1+ (1,0) [0|256] ""  FoxESS_inverter
-
-BO_ 6258 BMS_Limits: 8 FoxESS_inverter
- SG_ batt_voltage_max : 0|16@1+ (0.1,0) [380|400] "V"  FoxESS_inverter
- SG_ batt_voltage_min : 16|16@1+ (0.1,0) [290|330] "V"  FoxESS_inverter
- SG_ max_charge_rate : 32|16@1+ (0.1,0) [0|253] "A"  FoxESS_inverter
- SG_ max_discharge_rate : 48|16@1+ (0.1,0) [0|35] "A"  FoxESS_inverter
-
-BO_ 6259 BMS_PackData: 8 FoxESS_inverter
- SG_ pack_voltage : 0|16@1+ (0.1,0) [290|400] "V"  FoxESS_inverter
- SG_ pack_current_sense : 16|16@1- (0.1,0) [-40|40] "A"  FoxESS_inverter
- SG_ pack_soc : 32|8@1+ (1,0) [0|100] "%"  FoxESS_inverter
- SG_ pack_kwh_remain : 48|16@1+ (0.01,0) [0|100] "kWh"  FoxESS_inverter
-
-BO_ 6260 BMS_CellData: 8 FoxESS_inverter
- SG_ pack_cell_temp_high : 0|16@1- (0.1,0) [-40|60] "C"  FoxESS_inverter
- SG_ pack_cell_temp_low : 16|16@1- (0.1,0) [-40|60] "C"  FoxESS_inverter
- SG_ nu_cell_volts_high : 32|16@1+ (100,0) [2900|4200] "mV"  FoxESS_inverter
- SG_ nu_cell_volts_low : 48|16@1+ (100,0) [2900|4200] "mV"  FoxESS_inverter
-
-BO_ 6261 BMS_Status: 8 FoxESS_inverter
- SG_ BMS_temperature : 0|16@1- (0.1,0) [-40|60] "C"  FoxESS_inverter
- SG_ pack1_ok : 16|1@1+ (1,0) [0|1] ""  FoxESS_inverter
- SG_ pack2_ok : 17|1@1+ (1,0) [0|1] ""  FoxESS_inverter
- SG_ pack3_ok : 18|1@1+ (1,0) [0|1] ""  FoxESS_inverter
- SG_ pack4_ok : 19|1@1+ (1,0) [0|1] ""  FoxESS_inverter
- SG_ pack5_ok : 20|1@1+ (1,0) [0|1] ""  FoxESS_inverter
- SG_ pack6_ok : 21|1@1+ (1,0) [0|1] ""  FoxESS_inverter
- SG_ pack7_ok : 22|1@1+ (1,0) [0|1] ""  FoxESS_inverter
- SG_ pack8_ok : 23|1@1+ (1,0) [0|1] ""  FoxESS_inverter
- SG_ contactor : 32|1@1+ (1,0) [0|1] ""  FoxESS_inverter
- SG_ cycle_count : 48|16@1+ (1,0) [1|65535] "~"  FoxESS_inverter
- SG_ num_packs : 24|8@1- (1,0) [0|1] ""  FoxESS_inverter
-
-BO_ 6262 BMS_PackTemps: 8 FoxESS_inverter
- SG_ bit : 0|1@1+ (1,0) [0|1] ""  FoxESS_inverter
- SG_ pack_cell_millivolts_high : 16|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
- SG_ pack_cell_millivolts_low : 48|16@1+ (1,0) [2900|4200] "mV"  FoxESS_inverter
-
-BO_ 6263 BMS_PackInfo: 8 FoxESS_inverter
- SG_ pack_error : 0|8@1+ (1,0) [0|1] ""  FoxESS_inverter
- SG_ fv_pack_minor : 48|4@1+ (1,0) [0|1] ""  FoxESS_inverter
- SG_ fv_pack_major : 52|4@1+ (1,0) [0|1] ""  FoxESS_inverter
-
-BO_ 6264 BMS_PackStats: 8 FoxESS_inverter
- SG_ max_ac_voltage : 0|16@1+ (0.1,0) [290|400] "V"  FoxESS_inverter
- SG_ total_watt_hrs : 32|32@1+ (1,0) [0|429497000] "Wh"  FoxESS_inverter
-
-BO_ 6265 BMS_PackState: 8 FoxESS_inverter
- SG_ b0_idle : 8|1@1+ (1,0) [0|1] ""  FoxESS_inverter
- SG_ b1_ok_discharge : 9|1@1+ (1,0) [0|1] ""  FoxESS_inverter
- SG_ b2_ok_charge : 10|1@1+ (1,0) [0|1] ""  FoxESS_inverter
- SG_ b3_discharging : 11|1@1+ (1,0) [0|1] ""  FoxESS_inverter
- SG_ b4_charging : 12|1@1+ (1,0) [0|1] ""  FoxESS_inverter
- SG_ b5_operational : 13|1@1+ (1,0) [0|1] ""  FoxESS_inverter
- SG_ b6_active_error : 14|1@1+ (1,0) [0|1] ""  FoxESS_inverter
-
-BO_ 3361 BMS_CellTemps: 8 FoxESS_inverter
- SG_ C1_Temp1 : 0|8@1+ (1,-50) [0|60] "C"  FoxESS_inverter
- SG_ C1_Temp2 : 8|8@1+ (1,-50) [0|60] "C"  FoxESS_inverter
- SG_ C1_Temp3 : 16|8@1+ (1,-50) [0|60] "C"  FoxESS_inverter
- SG_ C1_Temp4 : 24|8@1+ (1,-50) [0|60] "C"  FoxESS_inverter
- SG_ C1_Temp5 : 32|8@1+ (1,-50) [0|60] "C"  FoxESS_inverter
- SG_ C1_Temp6 : 40|8@1+ (1,-50) [0|60] "C"  FoxESS_inverter
- SG_ C1_Temp7 : 48|8@1+ (1,-50) [0|60] "C"  FoxESS_inverter
- SG_ C1_Temp8 : 56|8@1+ (1,-50) [0|60] "C"  FoxESS_inverter
-
-BO_ 3369 BMS_CellTemps: 8 FoxESS_inverter
- SG_ C2_Temp1 : 0|8@1+ (1,-50) [0|60] "C"  FoxESS_inverter
- SG_ C2_Temp2 : 8|8@1+ (1,-50) [0|60] "C"  FoxESS_inverter
- SG_ C2_Temp3 : 16|8@1+ (1,-50) [0|60] "C"  FoxESS_inverter
- SG_ C2_Temp4 : 24|8@1+ (1,-50) [0|60] "C"  FoxESS_inverter
- SG_ C2_Temp5 : 32|8@1+ (1,-50) [0|60] "C"  FoxESS_inverter
- SG_ C2_Temp6 : 40|8@1+ (1,-50) [0|60] "C"  FoxESS_inverter
- SG_ C2_Temp7 : 48|8@1+ (1,-50) [0|60] "C"  FoxESS_inverter
- SG_ C2_Temp8 : 56|8@1+ (1,-50) [0|60] "C"  FoxESS_inverter
-
-BO_ 3377 BMS_CellTemps: 8 FoxESS_inverter
- SG_ C3_Temp1 : 0|8@1+ (1,-50) [0|60] "C"  FoxESS_inverter
- SG_ C3_Temp2 : 8|8@1+ (1,-50) [0|60] "C"  FoxESS_inverter
- SG_ C3_Temp3 : 16|8@1+ (1,-50) [0|60] "C"  FoxESS_inverter
- SG_ C3_Temp4 : 24|8@1+ (1,-50) [0|60] "C"  FoxESS_inverter
- SG_ C3_Temp5 : 32|8@1+ (1,-50) [0|60] "C"  FoxESS_inverter
- SG_ C3_Temp6 : 40|8@1+ (1,-50) [0|60] "C"  FoxESS_inverter
- SG_ C3_Temp7 : 48|8@1+ (1,-50) [0|60] "C"  FoxESS_inverter
- SG_ C3_Temp8 : 56|8@1+ (1,-50) [0|60] "C"  FoxESS_inverter
-
-BO_ 3385 BMS_CellTemps: 8 FoxESS_inverter
- SG_ C4_Temp1 : 0|8@1+ (1,-50) [0|60] "C"  FoxESS_inverter
- SG_ C4_Temp2 : 8|8@1+ (1,-50) [0|60] "C"  FoxESS_inverter
- SG_ C4_Temp3 : 16|8@1+ (1,-50) [0|60] "C"  FoxESS_inverter
- SG_ C4_Temp4 : 24|8@1+ (1,-50) [0|60] "C"  FoxESS_inverter
- SG_ C4_Temp5 : 32|8@1+ (1,-50) [0|60] "C"  FoxESS_inverter
- SG_ C4_Temp6 : 40|8@1+ (1,-50) [0|60] "C"  FoxESS_inverter
- SG_ C4_Temp7 : 48|8@1+ (1,-50) [0|60] "C"  FoxESS_inverter
- SG_ C4_Temp8 : 56|8@1+ (1,-50) [0|60] "C"  FoxESS_inverter
-
-BO_ 3393 BMS_CellTemps: 8 FoxESS_inverter
- SG_ C5_Temp1 : 0|8@1+ (1,-50) [0|60] "C"  FoxESS_inverter
- SG_ C5_Temp2 : 8|8@1+ (1,-50) [0|60] "C"  FoxESS_inverter
- SG_ C5_Temp3 : 16|8@1+ (1,-50) [0|60] "C"  FoxESS_inverter
- SG_ C5_Temp4 : 24|8@1+ (1,-50) [0|60] "C"  FoxESS_inverter
- SG_ C5_Temp5 : 32|8@1+ (1,-50) [0|60] "C"  FoxESS_inverter
- SG_ C5_Temp6 : 40|8@1+ (1,-50) [0|60] "C"  FoxESS_inverter
- SG_ C5_Temp7 : 48|8@1+ (1,-50) [0|60] "C"  FoxESS_inverter
- SG_ C5_Temp8 : 56|8@1+ (1,-50) [0|60] "C"  FoxESS_inverter
-
-BO_ 3401 BMS_CellTemps: 8 FoxESS_inverter
- SG_ C6_Temp1 : 0|8@1+ (1,-50) [0|60] "C"  FoxESS_inverter
- SG_ C6_Temp2 : 8|8@1+ (1,-50) [0|60] "C"  FoxESS_inverter
- SG_ C6_Temp3 : 16|8@1+ (1,-50) [0|60] "C"  FoxESS_inverter
- SG_ C6_Temp4 : 24|8@1+ (1,-50) [0|60] "C"  FoxESS_inverter
- SG_ C6_Temp5 : 32|8@1+ (1,-50) [0|60] "C"  FoxESS_inverter
- SG_ C6_Temp6 : 40|8@1+ (1,-50) [0|60] "C"  FoxESS_inverter
- SG_ C6_Temp7 : 48|8@1+ (1,-50) [0|60] "C"  FoxESS_inverter
- SG_ C6_Temp8 : 56|8@1+ (1,-50) [0|60] "C"  FoxESS_inverter
-
-BO_ 3409 BMS_CellTemps: 8 FoxESS_inverter
- SG_ C7_Temp1 : 0|8@1+ (1,-50) [0|60] "C"  FoxESS_inverter
- SG_ C7_Temp2 : 8|8@1+ (1,-50) [0|60] "C"  FoxESS_inverter
- SG_ C7_Temp3 : 16|8@1+ (1,-50) [0|60] "C"  FoxESS_inverter
- SG_ C7_Temp4 : 24|8@1+ (1,-50) [0|60] "C"  FoxESS_inverter
- SG_ C7_Temp5 : 32|8@1+ (1,-50) [0|60] "C"  FoxESS_inverter
- SG_ C7_Temp6 : 40|8@1+ (1,-50) [0|60] "C"  FoxESS_inverter
- SG_ C7_Temp7 : 48|8@1+ (1,-50) [0|60] "C"  FoxESS_inverter
- SG_ C7_Temp8 : 56|8@1+ (1,-50) [0|60] "C"  FoxESS_inverter
-
-BO_ 3417 BMS_CellTemps: 8 FoxESS_inverter
- SG_ C8_Temp1 : 0|8@1+ (1,-50) [0|60] "C"  FoxESS_inverter
- SG_ C8_Temp2 : 8|8@1+ (1,-50) [0|60] "C"  FoxESS_inverter
- SG_ C8_Temp3 : 16|8@1+ (1,-50) [0|60] "C"  FoxESS_inverter
- SG_ C8_Temp4 : 24|8@1+ (1,-50) [0|60] "C"  FoxESS_inverter
- SG_ C8_Temp5 : 32|8@1+ (1,-50) [0|60] "C"  FoxESS_inverter
- SG_ C8_Temp6 : 40|8@1+ (1,-50) [0|60] "C"  FoxESS_inverter
- SG_ C8_Temp7 : 48|8@1+ (1,-50) [0|60] "C"  FoxESS_inverter
- SG_ C8_Temp8 : 56|8@1+ (1,-50) [0|60] "C"  FoxESS_inverter
-
-BO_ 3077 Pack_1: 8 FoxESS_inverter
- SG_ current_sensor : 0|16@1- (0.1,0) [0|1] "A"  FoxESS_inverter
- SG_ Pack_Temp_Avg_Hi : 16|8@1+ (1,-50) [0|60] "C"  FoxESS_inverter
- SG_ Pack_Temp_Avg_Lo : 24|8@1+ (1,-50) [0|60] "C"  FoxESS_inverter
- SG_ Pack_SoC : 32|8@1+ (1,0) [0|1] "%"  FoxESS_inverter
- SG_ Pack_Volts : 48|16@1+ (0.001,0) [0|1] "V"  FoxESS_inverter
-
-BO_ 3078 Pack_2: 8 FoxESS_inverter
- SG_ current_sensor : 0|16@1- (0.1,0) [0|1] "A"  FoxESS_inverter
- SG_ Pack_Temp_Avg_Hi : 16|8@1+ (1,-50) [0|60] "C"  FoxESS_inverter
- SG_ Pack_Temp_Avg_Lo : 24|8@1+ (1,-50) [0|60] "C"  FoxESS_inverter
- SG_ Pack_SoC : 32|8@1+ (1,0) [0|1] "%"  FoxESS_inverter
- SG_ Pack_Volts : 48|16@1+ (0.001,0) [0|1] "V"  FoxESS_inverter
-
-BO_ 3079 Pack_3: 8 FoxESS_inverter
- SG_ current_sensor : 0|16@1- (0.1,0) [0|1] "A"  FoxESS_inverter
- SG_ Pack_Temp_Avg_Hi : 16|8@1+ (1,-50) [0|60] "C"  FoxESS_inverter
- SG_ Pack_Temp_Avg_Lo : 24|8@1+ (1,-50) [0|60] "C"  FoxESS_inverter
- SG_ Pack_SoC : 32|8@1+ (1,0) [0|1] "%"  FoxESS_inverter
- SG_ Pack_Volts : 48|16@1+ (0.001,0) [0|1] "V"  FoxESS_inverter
-
-BO_ 3080 Pack_4: 8 FoxESS_inverter
- SG_ current_sensor : 0|16@1- (0.1,0) [0|1] "A"  FoxESS_inverter
- SG_ Pack_Temp_Avg_Hi : 16|8@1+ (1,-50) [0|60] "C"  FoxESS_inverter
- SG_ Pack_Temp_Avg_Lo : 24|8@1+ (1,-50) [0|60] "C"  FoxESS_inverter
- SG_ Pack_SoC : 32|8@1+ (1,0) [0|1] "%"  FoxESS_inverter
- SG_ Pack_Volts : 48|16@1+ (0.001,0) [0|1] "V"  FoxESS_inverter
-
-BO_ 3081 Pack_5: 8 FoxESS_inverter
- SG_ current_sensor : 0|16@1- (0.1,0) [0|1] "A"  FoxESS_inverter
- SG_ Pack_Temp_Avg_Hi : 16|8@1+ (1,-50) [0|60] "C"  FoxESS_inverter
- SG_ Pack_Temp_Avg_Lo : 24|8@1+ (1,-50) [0|60] "C"  FoxESS_inverter
- SG_ Pack_SoC : 32|8@1+ (1,0) [0|1] "%"  FoxESS_inverter
- SG_ Pack_Volts : 48|16@1+ (0.001,0) [0|1] "V"  FoxESS_inverter
-
-BO_ 3082 Pack_6: 8 FoxESS_inverter
- SG_ current_sensor : 0|16@1- (0.1,0) [0|1] "A"  FoxESS_inverter
- SG_ Pack_Temp_Avg_Hi : 16|8@1+ (1,-50) [0|60] "C"  FoxESS_inverter
- SG_ Pack_Temp_Avg_Lo : 24|8@1+ (1,-50) [0|60] "C"  FoxESS_inverter
- SG_ Pack_SoC : 32|8@1+ (1,0) [0|1] "%"  FoxESS_inverter
- SG_ Pack_Volts : 48|16@1+ (0.001,0) [0|1] "V"  FoxESS_inverter
-
-BO_ 3083 Pack_7: 8 FoxESS_inverter
- SG_ current_sensor : 0|16@1- (0.1,0) [0|1] "A"  FoxESS_inverter
- SG_ Pack_Temp_Avg_Hi : 16|8@1+ (1,-50) [0|60] "C"  FoxESS_inverter
- SG_ Pack_Temp_Avg_Lo : 24|8@1+ (1,-50) [0|60] "C"  FoxESS_inverter
- SG_ Pack_SoC : 32|8@1+ (1,0) [0|1] "%"  FoxESS_inverter
- SG_ Pack_Volts : 48|16@1+ (0.001,0) [0|1] "V"  FoxESS_inverter
-
-BO_ 3084 Pack_8: 8 FoxESS_inverter
- SG_ current_sensor : 0|16@1- (0.1,0) [0|1] "A"  FoxESS_inverter
- SG_ Pack_Temp_Avg_Hi : 16|8@1+ (1,-50) [0|60] "C"  FoxESS_inverter
- SG_ Pack_Temp_Avg_Lo : 24|8@1+ (1,-50) [0|60] "C"  FoxESS_inverter
- SG_ Pack_SoC : 32|8@1+ (1,0) [0|1] "%"  FoxESS_inverter
- SG_ Pack_Volts : 48|16@1+ (0.001,0) [0|1] "V"  FoxESS_inverter
-
-BO_ 6273 BMS_1881: 8 FoxESS_inverter
- SG_ Pack_ID : 0|8@1+ (1,0) [0|1] "" FoxESS_inverter
- SG_ reg_B1 : 8|8@1+ (1,0) [0|1] "" FoxESS_inverter
- SG_ reg_B2 : 16|8@1+ (1,0) [0|1] "" FoxESS_inverter
- SG_ reg_B3 : 24|8@1+ (1,0) [0|1] "" FoxESS_inverter
- SG_ reg_B4 : 32|8@1+ (1,0) [0|1] "" FoxESS_inverter
- SG_ reg_B5 : 40|8@1+ (1,0) [0|1] "" FoxESS_inverter
- SG_ reg_B6 : 48|8@1+ (1,0) [0|1] "" FoxESS_inverter
- SG_ reg_B7 : 56|8@1+ (1,0) [0|1] "" FoxESS_inverter
-
-BO_ 6274 BMS_1882: 8 FoxESS_inverter
- SG_ Pack_ID : 0|8@1+ (1,0) [0|1] "" FoxESS_inverter
- SG_ reg_B1 : 8|8@1+ (1,0) [0|1] "" FoxESS_inverter
- SG_ reg_B2 : 16|8@1+ (1,0) [0|1] "" FoxESS_inverter
- SG_ reg_B3 : 24|8@1+ (1,0) [0|1] "" FoxESS_inverter
- SG_ reg_B4 : 32|8@1+ (1,0) [0|1] "" FoxESS_inverter
- SG_ reg_B5 : 40|8@1+ (1,0) [0|1] "" FoxESS_inverter
- SG_ reg_B6 : 48|8@1+ (1,0) [0|1] "" FoxESS_inverter
- SG_ reg_B7 : 56|8@1+ (1,0) [0|1] "" FoxESS_inverter
-
-BO_ 6275 BMS_1883: 8 FoxESS_inverter
- SG_ Pack_ID : 0|8@1+ (1,0) [0|1] "" FoxESS_inverter
- SG_ reg_B1 : 8|8@1+ (1,0) [0|1] "" FoxESS_inverter
- SG_ reg_B2 : 16|8@1+ (1,0) [0|1] "" FoxESS_inverter
- SG_ reg_B3 : 24|8@1+ (1,0) [0|1] "" FoxESS_inverter
- SG_ reg_B4 : 32|8@1+ (1,0) [0|1] "" FoxESS_inverter
- SG_ reg_B5 : 40|8@1+ (1,0) [0|1] "" FoxESS_inverter
- SG_ reg_B6 : 48|8@1+ (1,0) [0|1] "" FoxESS_inverter
- SG_ reg_B7 : 56|8@1+ (1,0) [0|1] "" FoxESS_inverter
-
-BA_DEF_ BO_ "GenMsgBackgroundColor" STRING ;
-BA_DEF_ BO_ "GenMsgForegroundColor" STRING ;
-BA_DEF_ BO_ "labelfilters" INT 0 0;
-BA_DEF_ BO_ "matchingcriteria" INT 0 0;
-BA_DEF_DEF_ "GenMsgBackgroundColor" "#1e1e1e";
-BA_DEF_DEF_ "GenMsgForegroundColor" "#ffffff";
-BA_DEF_DEF_ "labelfilters" 1;
-BA_DEF_DEF_ "matchingcriteria" 0;
-
-
-VAL_ 6273 reg_B1 48 "0" 49 "1" 50 "2" 51 "3" 52 "4" 53 "5" 54 "6" 55 "7" 56 "8" 57 "9" 65 "A" 66 "B" 67 "C" 68 "D" 69 "E" 70 "F" 71 "G" 72 "H" 73 "I" 74 "J" 75 "K" 76 "L" 77 "M" 78 "N" 79 "O" 80 "P" 81 "Q" 82 "R" 83 "S" 84 "T" 85 "U" 86 "V" 87 "W" 88 "X" 89 "Y" 90 "Z";
-VAL_ 6273 reg_B2 48 "0" 49 "1" 50 "2" 51 "3" 52 "4" 53 "5" 54 "6" 55 "7" 56 "8" 57 "9" 65 "A" 66 "B" 67 "C" 68 "D" 69 "E" 70 "F" 71 "G" 72 "H" 73 "I" 74 "J" 75 "K" 76 "L" 77 "M" 78 "N" 79 "O" 80 "P" 81 "Q" 82 "R" 83 "S" 84 "T" 85 "U" 86 "V" 87 "W" 88 "X" 89 "Y" 90 "Z";
-VAL_ 6273 reg_B3 48 "0" 49 "1" 50 "2" 51 "3" 52 "4" 53 "5" 54 "6" 55 "7" 56 "8" 57 "9" 65 "A" 66 "B" 67 "C" 68 "D" 69 "E" 70 "F" 71 "G" 72 "H" 73 "I" 74 "J" 75 "K" 76 "L" 77 "M" 78 "N" 79 "O" 80 "P" 81 "Q" 82 "R" 83 "S" 84 "T" 85 "U" 86 "V" 87 "W" 88 "X" 89 "Y" 90 "Z";
-VAL_ 6273 reg_B4 48 "0" 49 "1" 50 "2" 51 "3" 52 "4" 53 "5" 54 "6" 55 "7" 56 "8" 57 "9" 65 "A" 66 "B" 67 "C" 68 "D" 69 "E" 70 "F" 71 "G" 72 "H" 73 "I" 74 "J" 75 "K" 76 "L" 77 "M" 78 "N" 79 "O" 80 "P" 81 "Q" 82 "R" 83 "S" 84 "T" 85 "U" 86 "V" 87 "W" 88 "X" 89 "Y" 90 "Z";
-VAL_ 6273 reg_B5 48 "0" 49 "1" 50 "2" 51 "3" 52 "4" 53 "5" 54 "6" 55 "7" 56 "8" 57 "9" 65 "A" 66 "B" 67 "C" 68 "D" 69 "E" 70 "F" 71 "G" 72 "H" 73 "I" 74 "J" 75 "K" 76 "L" 77 "M" 78 "N" 79 "O" 80 "P" 81 "Q" 82 "R" 83 "S" 84 "T" 85 "U" 86 "V" 87 "W" 88 "X" 89 "Y" 90 "Z";
-VAL_ 6273 reg_B6 48 "0" 49 "1" 50 "2" 51 "3" 52 "4" 53 "5" 54 "6" 55 "7" 56 "8" 57 "9" 65 "A" 66 "B" 67 "C" 68 "D" 69 "E" 70 "F" 71 "G" 72 "H" 73 "I" 74 "J" 75 "K" 76 "L" 77 "M" 78 "N" 79 "O" 80 "P" 81 "Q" 82 "R" 83 "S" 84 "T" 85 "U" 86 "V" 87 "W" 88 "X" 89 "Y" 90 "Z";
-VAL_ 6273 reg_B7 48 "0" 49 "1" 50 "2" 51 "3" 52 "4" 53 "5" 54 "6" 55 "7" 56 "8" 57 "9" 65 "A" 66 "B" 67 "C" 68 "D" 69 "E" 70 "F" 71 "G" 72 "H" 73 "I" 74 "J" 75 "K" 76 "L" 77 "M" 78 "N" 79 "O" 80 "P" 81 "Q" 82 "R" 83 "S" 84 "T" 85 "U" 86 "V" 87 "W" 88 "X" 89 "Y" 90 "Z";
-VAL_ 6274 reg_B1 48 "0" 49 "1" 50 "2" 51 "3" 52 "4" 53 "5" 54 "6" 55 "7" 56 "8" 57 "9" 65 "A" 66 "B" 67 "C" 68 "D" 69 "E" 70 "F" 71 "G" 72 "H" 73 "I" 74 "J" 75 "K" 76 "L" 77 "M" 78 "N" 79 "O" 80 "P" 81 "Q" 82 "R" 83 "S" 84 "T" 85 "U" 86 "V" 87 "W" 88 "X" 89 "Y" 90 "Z";
-VAL_ 6274 reg_B2 48 "0" 49 "1" 50 "2" 51 "3" 52 "4" 53 "5" 54 "6" 55 "7" 56 "8" 57 "9" 65 "A" 66 "B" 67 "C" 68 "D" 69 "E" 70 "F" 71 "G" 72 "H" 73 "I" 74 "J" 75 "K" 76 "L" 77 "M" 78 "N" 79 "O" 80 "P" 81 "Q" 82 "R" 83 "S" 84 "T" 85 "U" 86 "V" 87 "W" 88 "X" 89 "Y" 90 "Z";
-VAL_ 6274 reg_B3 48 "0" 49 "1" 50 "2" 51 "3" 52 "4" 53 "5" 54 "6" 55 "7" 56 "8" 57 "9" 65 "A" 66 "B" 67 "C" 68 "D" 69 "E" 70 "F" 71 "G" 72 "H" 73 "I" 74 "J" 75 "K" 76 "L" 77 "M" 78 "N" 79 "O" 80 "P" 81 "Q" 82 "R" 83 "S" 84 "T" 85 "U" 86 "V" 87 "W" 88 "X" 89 "Y" 90 "Z";
-VAL_ 6274 reg_B4 48 "0" 49 "1" 50 "2" 51 "3" 52 "4" 53 "5" 54 "6" 55 "7" 56 "8" 57 "9" 65 "A" 66 "B" 67 "C" 68 "D" 69 "E" 70 "F" 71 "G" 72 "H" 73 "I" 74 "J" 75 "K" 76 "L" 77 "M" 78 "N" 79 "O" 80 "P" 81 "Q" 82 "R" 83 "S" 84 "T" 85 "U" 86 "V" 87 "W" 88 "X" 89 "Y" 90 "Z";
-VAL_ 6274 reg_B5 48 "0" 49 "1" 50 "2" 51 "3" 52 "4" 53 "5" 54 "6" 55 "7" 56 "8" 57 "9" 65 "A" 66 "B" 67 "C" 68 "D" 69 "E" 70 "F" 71 "G" 72 "H" 73 "I" 74 "J" 75 "K" 76 "L" 77 "M" 78 "N" 79 "O" 80 "P" 81 "Q" 82 "R" 83 "S" 84 "T" 85 "U" 86 "V" 87 "W" 88 "X" 89 "Y" 90 "Z";
-VAL_ 6274 reg_B6 48 "0" 49 "1" 50 "2" 51 "3" 52 "4" 53 "5" 54 "6" 55 "7" 56 "8" 57 "9" 65 "A" 66 "B" 67 "C" 68 "D" 69 "E" 70 "F" 71 "G" 72 "H" 73 "I" 74 "J" 75 "K" 76 "L" 77 "M" 78 "N" 79 "O" 80 "P" 81 "Q" 82 "R" 83 "S" 84 "T" 85 "U" 86 "V" 87 "W" 88 "X" 89 "Y" 90 "Z";
-VAL_ 6274 reg_B7 48 "0" 49 "1" 50 "2" 51 "3" 52 "4" 53 "5" 54 "6" 55 "7" 56 "8" 57 "9" 65 "A" 66 "B" 67 "C" 68 "D" 69 "E" 70 "F" 71 "G" 72 "H" 73 "I" 74 "J" 75 "K" 76 "L" 77 "M" 78 "N" 79 "O" 80 "P" 81 "Q" 82 "R" 83 "S" 84 "T" 85 "U" 86 "V" 87 "W" 88 "X" 89 "Y" 90 "Z";
-VAL_ 6275 reg_B1 48 "0" 49 "1" 50 "2" 51 "3" 52 "4" 53 "5" 54 "6" 55 "7" 56 "8" 57 "9" 65 "A" 66 "B" 67 "C" 68 "D" 69 "E" 70 "F" 71 "G" 72 "H" 73 "I" 74 "J" 75 "K" 76 "L" 77 "M" 78 "N" 79 "O" 80 "P" 81 "Q" 82 "R" 83 "S" 84 "T" 85 "U" 86 "V" 87 "W" 88 "X" 89 "Y" 90 "Z";
-VAL_ 6275 reg_B2 48 "0" 49 "1" 50 "2" 51 "3" 52 "4" 53 "5" 54 "6" 55 "7" 56 "8" 57 "9" 65 "A" 66 "B" 67 "C" 68 "D" 69 "E" 70 "F" 71 "G" 72 "H" 73 "I" 74 "J" 75 "K" 76 "L" 77 "M" 78 "N" 79 "O" 80 "P" 81 "Q" 82 "R" 83 "S" 84 "T" 85 "U" 86 "V" 87 "W" 88 "X" 89 "Y" 90 "Z";
-VAL_ 6275 reg_B3 48 "0" 49 "1" 50 "2" 51 "3" 52 "4" 53 "5" 54 "6" 55 "7" 56 "8" 57 "9" 65 "A" 66 "B" 67 "C" 68 "D" 69 "E" 70 "F" 71 "G" 72 "H" 73 "I" 74 "J" 75 "K" 76 "L" 77 "M" 78 "N" 79 "O" 80 "P" 81 "Q" 82 "R" 83 "S" 84 "T" 85 "U" 86 "V" 87 "W" 88 "X" 89 "Y" 90 "Z";
-VAL_ 6275 reg_B4 48 "0" 49 "1" 50 "2" 51 "3" 52 "4" 53 "5" 54 "6" 55 "7" 56 "8" 57 "9" 65 "A" 66 "B" 67 "C" 68 "D" 69 "E" 70 "F" 71 "G" 72 "H" 73 "I" 74 "J" 75 "K" 76 "L" 77 "M" 78 "N" 79 "O" 80 "P" 81 "Q" 82 "R" 83 "S" 84 "T" 85 "U" 86 "V" 87 "W" 88 "X" 89 "Y" 90 "Z";
-VAL_ 6275 reg_B5 48 "0" 49 "1" 50 "2" 51 "3" 52 "4" 53 "5" 54 "6" 55 "7" 56 "8" 57 "9" 65 "A" 66 "B" 67 "C" 68 "D" 69 "E" 70 "F" 71 "G" 72 "H" 73 "I" 74 "J" 75 "K" 76 "L" 77 "M" 78 "N" 79 "O" 80 "P" 81 "Q" 82 "R" 83 "S" 84 "T" 85 "U" 86 "V" 87 "W" 88 "X" 89 "Y" 90 "Z";
-VAL_ 6275 reg_B6 48 "0" 49 "1" 50 "2" 51 "3" 52 "4" 53 "5" 54 "6" 55 "7" 56 "8" 57 "9" 65 "A" 66 "B" 67 "C" 68 "D" 69 "E" 70 "F" 71 "G" 72 "H" 73 "I" 74 "J" 75 "K" 76 "L" 77 "M" 78 "N" 79 "O" 80 "P" 81 "Q" 82 "R" 83 "S" 84 "T" 85 "U" 86 "V" 87 "W" 88 "X" 89 "Y" 90 "Z";
-VAL_ 6275 reg_B7 48 "0" 49 "1" 50 "2" 51 "3" 52 "4" 53 "5" 54 "6" 55 "7" 56 "8" 57 "9" 65 "A" 66 "B" 67 "C" 68 "D" 69 "E" 70 "F" 71 "G" 72 "H" 73 "I" 74 "J" 75 "K" 76 "L" 77 "M" 78 "N" 79 "O" 80 "P" 81 "Q" 82 "R" 83 "S" 84 "T" 85 "U" 86 "V" 87 "W" 88 "X" 89 "Y" 90 "Z";
-
+BU_: FoxESS_battery FoxESS_inverter
+
+
+BO_ 2147486749 BMS_CellVolts1: 8 FoxESS_battery
+ SG_ cell_1_volts : 0|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+ SG_ cell_2_volts : 16|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+ SG_ cell_3_volts : 32|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+ SG_ cell_4_volts : 48|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+
+BO_ 2147486753 BMS_CellVolts2: 8 FoxESS_battery
+ SG_ cell_5_volts : 0|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+ SG_ cell_6_volts : 16|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+ SG_ cell_7_volts : 32|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+ SG_ cell_8_volts : 48|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+
+BO_ 2147486757 BMS_CellVolts3: 8 FoxESS_battery
+ SG_ cell_9_volts : 0|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+ SG_ cell_10_volts : 16|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+ SG_ cell_11_volts : 32|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+ SG_ cell_12_volts : 48|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+
+BO_ 2147486761 BMS_CellVolts4: 8 FoxESS_battery
+ SG_ cell_13_volts : 0|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+ SG_ cell_14_volts : 16|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+ SG_ cell_15_volts : 32|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+ SG_ cell_16_volts : 48|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+
+BO_ 2147486765 BMS_CellVolts5: 8 FoxESS_battery
+ SG_ cell_17_volts : 0|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+ SG_ cell_18_volts : 16|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+ SG_ cell_19_volts : 32|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+ SG_ cell_20_volts : 48|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+
+BO_ 2147486769 BMS_CellVolts6: 8 FoxESS_battery
+ SG_ cell_21_volts : 0|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+ SG_ cell_22_volts : 16|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+ SG_ cell_23_volts : 32|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+ SG_ cell_24_volts : 48|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+
+BO_ 2147486773 BMS_CellVolts7: 8 FoxESS_battery
+ SG_ cell_25_volts : 0|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+ SG_ cell_26_volts : 16|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+ SG_ cell_27_volts : 32|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+ SG_ cell_28_volts : 48|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+
+BO_ 2147486777 BMS_CellVolts8: 8 FoxESS_battery
+ SG_ cell_29_volts : 0|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+ SG_ cell_30_volts : 16|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+ SG_ cell_31_volts : 32|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+ SG_ cell_32_volts : 48|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+
+BO_ 2147486781 BMS_CellVolts9: 8 FoxESS_battery
+ SG_ cell_33_volts : 0|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+ SG_ cell_34_volts : 16|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+ SG_ cell_35_volts : 32|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+ SG_ cell_36_volts : 48|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+
+BO_ 2147486785 BMS_CellVolts10: 8 FoxESS_battery
+ SG_ cell_37_volts : 0|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+ SG_ cell_38_volts : 16|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+ SG_ cell_39_volts : 32|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+ SG_ cell_40_volts : 48|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+
+BO_ 2147486789 BMS_CellVolts11: 8 FoxESS_battery
+ SG_ cell_41_volts : 0|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+ SG_ cell_42_volts : 16|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+ SG_ cell_43_volts : 32|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+ SG_ cell_44_volts : 48|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+
+BO_ 2147486793 BMS_CellVolts12: 8 FoxESS_battery
+ SG_ cell_45_volts : 0|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+ SG_ cell_46_volts : 16|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+ SG_ cell_47_volts : 32|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+ SG_ cell_48_volts : 48|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+
+BO_ 2147486797 BMS_CellVolts13: 8 FoxESS_battery
+ SG_ cell_49_volts : 0|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+ SG_ cell_50_volts : 16|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+ SG_ cell_51_volts : 32|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+ SG_ cell_52_volts : 48|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+
+BO_ 2147486801 BMS_CellVolts14: 8 FoxESS_battery
+ SG_ cell_53_volts : 0|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+ SG_ cell_54_volts : 16|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+ SG_ cell_55_volts : 32|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+ SG_ cell_56_volts : 48|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+
+BO_ 2147486805 BMS_CellVolts15: 8 FoxESS_battery
+ SG_ cell_57_volts : 0|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+ SG_ cell_58_volts : 16|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+ SG_ cell_59_volts : 32|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+ SG_ cell_60_volts : 48|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+
+BO_ 2147486809 BMS_CellVolts16: 8 FoxESS_battery
+ SG_ cell_61_volts : 0|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+ SG_ cell_62_volts : 16|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+ SG_ cell_63_volts : 32|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+ SG_ cell_64_volts : 48|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+
+BO_ 2147486813 BMS_CellVolts17: 8 FoxESS_battery
+ SG_ cell65_volts : 0|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+ SG_ cell66_volts : 16|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+ SG_ cell67_volts : 32|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+ SG_ cell68_volts : 48|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+
+BO_ 2147486817 BMS_CellVolts18: 8 FoxESS_battery
+ SG_ cell69_volts : 0|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+ SG_ cell70_volts : 16|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+ SG_ cell71_volts : 32|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+ SG_ cell72_volts : 48|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+
+BO_ 2147486821 BMS_CellVolts19: 8 FoxESS_battery
+ SG_ cell73_volts : 0|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+ SG_ cell74_volts : 16|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+ SG_ cell75_volts : 32|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+ SG_ cell76_volts : 48|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+
+BO_ 2147486825 BMS_CellVolts20: 8 FoxESS_battery
+ SG_ cell77_volts : 0|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+ SG_ cell78_volts : 16|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+ SG_ cell79_volts : 32|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+ SG_ cell80_volts : 48|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+
+BO_ 2147486829 BMS_CellVolts21: 8 FoxESS_battery
+ SG_ cell81_volts : 0|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+ SG_ cell82_volts : 16|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+ SG_ cell83_volts : 32|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+ SG_ cell84_volts : 48|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+
+BO_ 2147486833 BMS_CellVolts22: 8 FoxESS_battery
+ SG_ cell85_volts : 0|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+ SG_ cell86_volts : 16|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+ SG_ cell87_volts : 32|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+ SG_ cell88_volts : 48|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+
+BO_ 2147486837 BMS_CellVolts23: 8 FoxESS_battery
+ SG_ cell89_volts : 0|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+ SG_ cell90_volts : 16|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+ SG_ cell91_volts : 32|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+ SG_ cell92_volts : 48|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+
+BO_ 2147486841 BMS_CellVolts24: 8 FoxESS_battery
+ SG_ cell93_volts : 0|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+ SG_ cell94_volts : 16|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+ SG_ cell95_volts : 32|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+ SG_ cell96_volts : 48|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+
+BO_ 2147486845 BMS_CellVolts25: 8 FoxESS_battery
+ SG_ cell97_volts : 0|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+ SG_ cell98_volts : 16|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+ SG_ cell99_volts : 32|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+ SG_ cell100_volts : 48|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+
+BO_ 2147486849 BMS_CellVolts26: 8 FoxESS_battery
+ SG_ cell101_volts : 0|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+ SG_ cell102_volts : 16|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+ SG_ cell103_volts : 32|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+ SG_ cell104_volts : 48|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+
+BO_ 2147486853 BMS_CellVolts27: 8 FoxESS_battery
+ SG_ cell105_volts : 0|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+ SG_ cell106_volts : 16|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+ SG_ cell107_volts : 32|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+ SG_ cell108_volts : 48|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+
+BO_ 2147486857 BMS_CellVolts28: 8 FoxESS_battery
+ SG_ cell109_volts : 0|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+ SG_ cell110_volts : 16|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+ SG_ cell111_volts : 32|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+ SG_ cell112_volts : 48|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+
+BO_ 2147486861 BMS_CellVolts29: 8 FoxESS_battery
+ SG_ cell113_volts : 0|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+ SG_ cell114_volts : 16|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+ SG_ cell115_volts : 32|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+ SG_ cell116_volts : 48|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+
+BO_ 2147486865 BMS_CellVolts30: 8 FoxESS_battery
+ SG_ cell117_volts : 0|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+ SG_ cell118_volts : 16|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+ SG_ cell119_volts : 32|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+ SG_ cell120_volts : 48|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+
+BO_ 2147486869 BMS_CellVolts31: 8 FoxESS_battery
+ SG_ cell121_volts : 0|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+ SG_ cell122_volts : 16|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+ SG_ cell123_volts : 32|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+ SG_ cell124_volts : 48|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+
+BO_ 2147486873 BMS_CellVolts31: 8 FoxESS_battery
+ SG_ cell125_volts : 0|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+ SG_ cell126_volts : 16|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+ SG_ cell127_volts : 32|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+ SG_ cell128_volts : 48|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+
+BO_ 2147486877 BMS_CellVolts31: 8 FoxESS_battery
+ SG_ cell129_volts : 0|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+ SG_ cell130_volts : 16|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+ SG_ cell131_volts : 32|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+ SG_ cell132_volts : 48|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+
+BO_ 2147486881 BMS_CellVolts31: 8 FoxESS_battery
+ SG_ cell133_volts : 0|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+ SG_ cell134_volts : 16|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+ SG_ cell135_volts : 32|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+ SG_ cell136_volts : 48|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+
+BO_ 2147486885 BMS_CellVolts31: 8 FoxESS_battery
+ SG_ cell137_volts : 0|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+ SG_ cell138_volts : 16|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+ SG_ cell139_volts : 32|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+ SG_ cell140_volts : 48|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+
+BO_ 2147486889 BMS_CellVolts31: 8 FoxESS_battery
+ SG_ cell141_volts : 0|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+ SG_ cell142_volts : 16|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+ SG_ cell143_volts : 32|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+ SG_ cell144_volts : 48|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+
+BO_ 2147489905 Inverter_Request: 8 FoxESS_inverter
+ SG_ Rqst_0 : 0|8@1+ (1,0) [0|256] ""  FoxESS_battery
+ SG_ Rqst_2 : 16|8@1+ (1,0) [0|256] ""  FoxESS_battery
+ SG_ Rqst_4 : 32|8@1+ (1,0) [0|256] ""  FoxESS_battery
+
+BO_ 2147489906 BMS_Limits: 8 FoxESS_battery
+ SG_ batt_voltage_max : 0|16@1+ (0.1,0) [380|400] "V"  FoxESS_battery
+ SG_ batt_voltage_min : 16|16@1+ (0.1,0) [290|330] "V"  FoxESS_battery
+ SG_ max_charge_rate : 32|16@1+ (0.1,0) [0|253] "A"  FoxESS_battery
+ SG_ max_discharge_rate : 48|16@1+ (0.1,0) [0|35] "A"  FoxESS_battery
+
+BO_ 2147489907 BMS_PackData: 8 FoxESS_battery
+ SG_ pack_voltage : 0|16@1+ (0.1,0) [290|400] "V"  FoxESS_battery
+ SG_ pack_current_sense : 16|16@1- (0.1,0) [-40|40] "A"  FoxESS_battery
+ SG_ pack_soc : 32|8@1+ (1,0) [0|100] "%"  FoxESS_battery
+ SG_ pack_kwh_remain : 48|16@1+ (0.01,0) [0|100] "kWh"  FoxESS_battery
+
+BO_ 2147489908 BMS_CellData: 8 FoxESS_battery
+ SG_ pack_cell_temp_high : 0|16@1- (0.1,0) [-40|60] "C"  FoxESS_battery
+ SG_ pack_cell_temp_low : 16|16@1- (0.1,0) [-40|60] "C"  FoxESS_battery
+ SG_ nu_cell_volts_high : 32|16@1+ (100,0) [2900|4200] "mV"  FoxESS_battery
+ SG_ nu_cell_volts_low : 48|16@1+ (100,0) [2900|4200] "mV"  FoxESS_battery
+
+BO_ 2147489909 BMS_Status: 8 FoxESS_battery
+ SG_ BMS_temperature : 0|16@1- (0.1,0) [-40|60] "C"  FoxESS_battery
+ SG_ pack1_ok : 16|1@1+ (1,0) [0|1] ""  FoxESS_battery
+ SG_ pack2_ok : 17|1@1+ (1,0) [0|1] ""  FoxESS_battery
+ SG_ pack3_ok : 18|1@1+ (1,0) [0|1] ""  FoxESS_battery
+ SG_ pack4_ok : 19|1@1+ (1,0) [0|1] ""  FoxESS_battery
+ SG_ pack5_ok : 20|1@1+ (1,0) [0|1] ""  FoxESS_battery
+ SG_ pack6_ok : 21|1@1+ (1,0) [0|1] ""  FoxESS_battery
+ SG_ pack7_ok : 22|1@1+ (1,0) [0|1] ""  FoxESS_battery
+ SG_ pack8_ok : 23|1@1+ (1,0) [0|1] ""  FoxESS_battery
+ SG_ contactor : 32|1@1+ (1,0) [0|1] ""  FoxESS_battery
+ SG_ cycle_count : 48|16@1+ (1,0) [1|65535] "~"  FoxESS_battery
+ SG_ num_packs : 24|8@1- (1,0) [0|1] ""  FoxESS_battery
+
+BO_ 2147489910 BMS_PackTemps: 8 FoxESS_battery
+ SG_ bit : 0|1@1+ (1,0) [0|1] ""  FoxESS_battery
+ SG_ pack_cell_millivolts_high : 16|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+ SG_ pack_cell_millivolts_low : 48|16@1+ (1,0) [2900|4200] "mV"  FoxESS_battery
+
+BO_ 2147489911 BMS_PackInfo: 8 FoxESS_battery
+ SG_ pack_error : 0|8@1+ (1,0) [0|1] ""  FoxESS_battery
+ SG_ fv_pack_minor : 48|4@1+ (1,0) [0|1] ""  FoxESS_battery
+ SG_ fv_pack_major : 52|4@1+ (1,0) [0|1] ""  FoxESS_battery
+
+BO_ 2147489912 BMS_PackStats: 8 FoxESS_battery
+ SG_ max_ac_voltage : 0|16@1+ (0.1,0) [290|400] "V"  FoxESS_battery
+ SG_ total_watt_hrs : 32|32@1+ (1,0) [0|429497000] "Wh"  FoxESS_battery
+
+BO_ 2147489913 BMS_PackState: 8 FoxESS_battery
+ SG_ b0_idle : 8|1@1+ (1,0) [0|1] ""  FoxESS_battery
+ SG_ b1_ok_discharge : 9|1@1+ (1,0) [0|1] ""  FoxESS_battery
+ SG_ b2_ok_charge : 10|1@1+ (1,0) [0|1] ""  FoxESS_battery
+ SG_ b3_discharging : 11|1@1+ (1,0) [0|1] ""  FoxESS_battery
+ SG_ b4_charging : 12|1@1+ (1,0) [0|1] ""  FoxESS_battery
+ SG_ b5_operational : 13|1@1+ (1,0) [0|1] ""  FoxESS_battery
+ SG_ b6_active_error : 14|1@1+ (1,0) [0|1] ""  FoxESS_battery
+
+BO_ 2147487009 BMS_CellTemps1: 8 FoxESS_battery
+ SG_ C1_Temp1 : 0|8@1+ (1,-50) [0|60] "C"  FoxESS_battery
+ SG_ C1_Temp2 : 8|8@1+ (1,-50) [0|60] "C"  FoxESS_battery
+ SG_ C1_Temp3 : 16|8@1+ (1,-50) [0|60] "C"  FoxESS_battery
+ SG_ C1_Temp4 : 24|8@1+ (1,-50) [0|60] "C"  FoxESS_battery
+ SG_ C1_Temp5 : 32|8@1+ (1,-50) [0|60] "C"  FoxESS_battery
+ SG_ C1_Temp6 : 40|8@1+ (1,-50) [0|60] "C"  FoxESS_battery
+ SG_ C1_Temp7 : 48|8@1+ (1,-50) [0|60] "C"  FoxESS_battery
+ SG_ C1_Temp8 : 56|8@1+ (1,-50) [0|60] "C"  FoxESS_battery
+
+BO_ 2147487017 BMS_CellTemps2: 8 FoxESS_battery
+ SG_ C2_Temp1 : 0|8@1+ (1,-50) [0|60] "C"  FoxESS_battery
+ SG_ C2_Temp2 : 8|8@1+ (1,-50) [0|60] "C"  FoxESS_battery
+ SG_ C2_Temp3 : 16|8@1+ (1,-50) [0|60] "C"  FoxESS_battery
+ SG_ C2_Temp4 : 24|8@1+ (1,-50) [0|60] "C"  FoxESS_battery
+ SG_ C2_Temp5 : 32|8@1+ (1,-50) [0|60] "C"  FoxESS_battery
+ SG_ C2_Temp6 : 40|8@1+ (1,-50) [0|60] "C"  FoxESS_battery
+ SG_ C2_Temp7 : 48|8@1+ (1,-50) [0|60] "C"  FoxESS_battery
+ SG_ C2_Temp8 : 56|8@1+ (1,-50) [0|60] "C"  FoxESS_battery
+
+BO_ 2147487025 BMS_CellTemps3: 8 FoxESS_battery
+ SG_ C3_Temp1 : 0|8@1+ (1,-50) [0|60] "C"  FoxESS_battery
+ SG_ C3_Temp2 : 8|8@1+ (1,-50) [0|60] "C"  FoxESS_battery
+ SG_ C3_Temp3 : 16|8@1+ (1,-50) [0|60] "C"  FoxESS_battery
+ SG_ C3_Temp4 : 24|8@1+ (1,-50) [0|60] "C"  FoxESS_battery
+ SG_ C3_Temp5 : 32|8@1+ (1,-50) [0|60] "C"  FoxESS_battery
+ SG_ C3_Temp6 : 40|8@1+ (1,-50) [0|60] "C"  FoxESS_battery
+ SG_ C3_Temp7 : 48|8@1+ (1,-50) [0|60] "C"  FoxESS_battery
+ SG_ C3_Temp8 : 56|8@1+ (1,-50) [0|60] "C"  FoxESS_battery
+
+BO_ 2147487033 BMS_CellTemps4: 8 FoxESS_battery
+ SG_ C4_Temp1 : 0|8@1+ (1,-50) [0|60] "C"  FoxESS_battery
+ SG_ C4_Temp2 : 8|8@1+ (1,-50) [0|60] "C"  FoxESS_battery
+ SG_ C4_Temp3 : 16|8@1+ (1,-50) [0|60] "C"  FoxESS_battery
+ SG_ C4_Temp4 : 24|8@1+ (1,-50) [0|60] "C"  FoxESS_battery
+ SG_ C4_Temp5 : 32|8@1+ (1,-50) [0|60] "C"  FoxESS_battery
+ SG_ C4_Temp6 : 40|8@1+ (1,-50) [0|60] "C"  FoxESS_battery
+ SG_ C4_Temp7 : 48|8@1+ (1,-50) [0|60] "C"  FoxESS_battery
+ SG_ C4_Temp8 : 56|8@1+ (1,-50) [0|60] "C"  FoxESS_battery
+
+BO_ 2147487041 BMS_CellTemps5: 8 FoxESS_battery
+ SG_ C5_Temp1 : 0|8@1+ (1,-50) [0|60] "C"  FoxESS_battery
+ SG_ C5_Temp2 : 8|8@1+ (1,-50) [0|60] "C"  FoxESS_battery
+ SG_ C5_Temp3 : 16|8@1+ (1,-50) [0|60] "C"  FoxESS_battery
+ SG_ C5_Temp4 : 24|8@1+ (1,-50) [0|60] "C"  FoxESS_battery
+ SG_ C5_Temp5 : 32|8@1+ (1,-50) [0|60] "C"  FoxESS_battery
+ SG_ C5_Temp6 : 40|8@1+ (1,-50) [0|60] "C"  FoxESS_battery
+ SG_ C5_Temp7 : 48|8@1+ (1,-50) [0|60] "C"  FoxESS_battery
+ SG_ C5_Temp8 : 56|8@1+ (1,-50) [0|60] "C"  FoxESS_battery
+
+BO_ 2147487049 BMS_CellTemps6: 8 FoxESS_battery
+ SG_ C6_Temp1 : 0|8@1+ (1,-50) [0|60] "C"  FoxESS_battery
+ SG_ C6_Temp2 : 8|8@1+ (1,-50) [0|60] "C"  FoxESS_battery
+ SG_ C6_Temp3 : 16|8@1+ (1,-50) [0|60] "C"  FoxESS_battery
+ SG_ C6_Temp4 : 24|8@1+ (1,-50) [0|60] "C"  FoxESS_battery
+ SG_ C6_Temp5 : 32|8@1+ (1,-50) [0|60] "C"  FoxESS_battery
+ SG_ C6_Temp6 : 40|8@1+ (1,-50) [0|60] "C"  FoxESS_battery
+ SG_ C6_Temp7 : 48|8@1+ (1,-50) [0|60] "C"  FoxESS_battery
+ SG_ C6_Temp8 : 56|8@1+ (1,-50) [0|60] "C"  FoxESS_battery
+
+BO_ 2147487057 BMS_CellTemps7: 8 FoxESS_battery
+ SG_ C7_Temp1 : 0|8@1+ (1,-50) [0|60] "C"  FoxESS_battery
+ SG_ C7_Temp2 : 8|8@1+ (1,-50) [0|60] "C"  FoxESS_battery
+ SG_ C7_Temp3 : 16|8@1+ (1,-50) [0|60] "C"  FoxESS_battery
+ SG_ C7_Temp4 : 24|8@1+ (1,-50) [0|60] "C"  FoxESS_battery
+ SG_ C7_Temp5 : 32|8@1+ (1,-50) [0|60] "C"  FoxESS_battery
+ SG_ C7_Temp6 : 40|8@1+ (1,-50) [0|60] "C"  FoxESS_battery
+ SG_ C7_Temp7 : 48|8@1+ (1,-50) [0|60] "C"  FoxESS_battery
+ SG_ C7_Temp8 : 56|8@1+ (1,-50) [0|60] "C"  FoxESS_battery
+
+BO_ 2147487065 BMS_CellTemps8: 8 FoxESS_battery
+ SG_ C8_Temp1 : 0|8@1+ (1,-50) [0|60] "C"  FoxESS_battery
+ SG_ C8_Temp2 : 8|8@1+ (1,-50) [0|60] "C"  FoxESS_battery
+ SG_ C8_Temp3 : 16|8@1+ (1,-50) [0|60] "C"  FoxESS_battery
+ SG_ C8_Temp4 : 24|8@1+ (1,-50) [0|60] "C"  FoxESS_battery
+ SG_ C8_Temp5 : 32|8@1+ (1,-50) [0|60] "C"  FoxESS_battery
+ SG_ C8_Temp6 : 40|8@1+ (1,-50) [0|60] "C"  FoxESS_battery
+ SG_ C8_Temp7 : 48|8@1+ (1,-50) [0|60] "C"  FoxESS_battery
+ SG_ C8_Temp8 : 56|8@1+ (1,-50) [0|60] "C"  FoxESS_battery
+
+BO_ 2147486725 Pack_1: 8 FoxESS_battery
+ SG_ current_sensor : 0|16@1- (0.1,0) [0|1] "A"  FoxESS_battery
+ SG_ Pack_Temp_Avg_Hi : 16|8@1+ (1,-50) [0|60] "C"  FoxESS_battery
+ SG_ Pack_Temp_Avg_Lo : 24|8@1+ (1,-50) [0|60] "C"  FoxESS_battery
+ SG_ Pack_SoC : 32|8@1+ (1,0) [0|1] "%"  FoxESS_battery
+ SG_ Pack_Volts : 48|16@1+ (0.001,0) [0|1] "V"  FoxESS_battery
+
+BO_ 2147484678 Pack_2: 8 FoxESS_battery
+ SG_ current_sensor : 0|16@1- (0.1,0) [0|1] "A"  FoxESS_battery
+ SG_ Pack_Temp_Avg_Hi : 16|8@1+ (1,-50) [0|60] "C"  FoxESS_battery
+ SG_ Pack_Temp_Avg_Lo : 24|8@1+ (1,-50) [0|60] "C"  FoxESS_battery
+ SG_ Pack_SoC : 32|8@1+ (1,0) [0|1] "%"  FoxESS_battery
+ SG_ Pack_Volts : 48|16@1+ (0.001,0) [0|1] "V"  FoxESS_battery
+
+BO_ 2147486727 Pack_3: 8 FoxESS_battery
+ SG_ current_sensor : 0|16@1- (0.1,0) [0|1] "A"  FoxESS_battery
+ SG_ Pack_Temp_Avg_Hi : 16|8@1+ (1,-50) [0|60] "C"  FoxESS_battery
+ SG_ Pack_Temp_Avg_Lo : 24|8@1+ (1,-50) [0|60] "C"  FoxESS_battery
+ SG_ Pack_SoC : 32|8@1+ (1,0) [0|1] "%"  FoxESS_battery
+ SG_ Pack_Volts : 48|16@1+ (0.001,0) [0|1] "V"  FoxESS_battery
+
+BO_ 2147486728 Pack_4: 8 FoxESS_battery
+ SG_ current_sensor : 0|16@1- (0.1,0) [0|1] "A"  FoxESS_battery
+ SG_ Pack_Temp_Avg_Hi : 16|8@1+ (1,-50) [0|60] "C"  FoxESS_battery
+ SG_ Pack_Temp_Avg_Lo : 24|8@1+ (1,-50) [0|60] "C"  FoxESS_battery
+ SG_ Pack_SoC : 32|8@1+ (1,0) [0|1] "%"  FoxESS_battery
+ SG_ Pack_Volts : 48|16@1+ (0.001,0) [0|1] "V"  FoxESS_battery
+
+BO_ 2147486729 Pack_5: 8 FoxESS_battery
+ SG_ current_sensor : 0|16@1- (0.1,0) [0|1] "A"  FoxESS_battery
+ SG_ Pack_Temp_Avg_Hi : 16|8@1+ (1,-50) [0|60] "C"  FoxESS_battery
+ SG_ Pack_Temp_Avg_Lo : 24|8@1+ (1,-50) [0|60] "C"  FoxESS_battery
+ SG_ Pack_SoC : 32|8@1+ (1,0) [0|1] "%"  FoxESS_battery
+ SG_ Pack_Volts : 48|16@1+ (0.001,0) [0|1] "V"  FoxESS_battery
+
+BO_ 2147486730 Pack_6: 8 FoxESS_battery
+ SG_ current_sensor : 0|16@1- (0.1,0) [0|1] "A"  FoxESS_battery
+ SG_ Pack_Temp_Avg_Hi : 16|8@1+ (1,-50) [0|60] "C"  FoxESS_battery
+ SG_ Pack_Temp_Avg_Lo : 24|8@1+ (1,-50) [0|60] "C"  FoxESS_battery
+ SG_ Pack_SoC : 32|8@1+ (1,0) [0|1] "%"  FoxESS_battery
+ SG_ Pack_Volts : 48|16@1+ (0.001,0) [0|1] "V"  FoxESS_battery
+
+BO_ 2147486731 Pack_7: 8 FoxESS_battery
+ SG_ current_sensor : 0|16@1- (0.1,0) [0|1] "A"  FoxESS_battery
+ SG_ Pack_Temp_Avg_Hi : 16|8@1+ (1,-50) [0|60] "C"  FoxESS_battery
+ SG_ Pack_Temp_Avg_Lo : 24|8@1+ (1,-50) [0|60] "C"  FoxESS_battery
+ SG_ Pack_SoC : 32|8@1+ (1,0) [0|1] "%"  FoxESS_battery
+ SG_ Pack_Volts : 48|16@1+ (0.001,0) [0|1] "V"  FoxESS_battery
+
+BO_ 2147486732 Pack_8: 8 FoxESS_battery
+ SG_ current_sensor : 0|16@1- (0.1,0) [0|1] "A"  FoxESS_battery
+ SG_ Pack_Temp_Avg_Hi : 16|8@1+ (1,-50) [0|60] "C"  FoxESS_battery
+ SG_ Pack_Temp_Avg_Lo : 24|8@1+ (1,-50) [0|60] "C"  FoxESS_battery
+ SG_ Pack_SoC : 32|8@1+ (1,0) [0|1] "%"  FoxESS_battery
+ SG_ Pack_Volts : 48|16@1+ (0.001,0) [0|1] "V"  FoxESS_battery
+
+BO_ 2147489921 BMS_1881: 8 FoxESS_battery
+ SG_ Pack_ID : 0|8@1+ (1,0) [0|1] ""  FoxESS_battery
+ SG_ reg_B1 : 8|8@1+ (1,0) [0|1] ""  FoxESS_battery
+ SG_ reg_B2 : 16|8@1+ (1,0) [0|1] ""  FoxESS_battery
+ SG_ reg_B3 : 24|8@1+ (1,0) [0|1] ""  FoxESS_battery
+ SG_ reg_B4 : 32|8@1+ (1,0) [0|1] ""  FoxESS_battery
+ SG_ reg_B5 : 40|8@1+ (1,0) [0|1] ""  FoxESS_battery
+ SG_ reg_B6 : 48|8@1+ (1,0) [0|1] ""  FoxESS_battery
+ SG_ reg_B7 : 56|8@1+ (1,0) [0|1] ""  FoxESS_battery
+
+BO_ 2147489922 BMS_1882: 8 FoxESS_battery
+ SG_ Pack_ID : 0|8@1+ (1,0) [0|1] ""  FoxESS_battery
+ SG_ reg_B1 : 8|8@1+ (1,0) [0|1] ""  FoxESS_battery
+ SG_ reg_B2 : 16|8@1+ (1,0) [0|1] ""  FoxESS_battery
+ SG_ reg_B3 : 24|8@1+ (1,0) [0|1] ""  FoxESS_battery
+ SG_ reg_B4 : 32|8@1+ (1,0) [0|1] ""  FoxESS_battery
+ SG_ reg_B5 : 40|8@1+ (1,0) [0|1] ""  FoxESS_battery
+ SG_ reg_B6 : 48|8@1+ (1,0) [0|1] ""  FoxESS_battery
+ SG_ reg_B7 : 56|8@1+ (1,0) [0|1] ""  FoxESS_battery
+
+BO_ 2147489923 BMS_1883: 8 FoxESS_battery
+ SG_ Pack_ID : 0|8@1+ (1,0) [0|1] ""  FoxESS_battery
+ SG_ reg_B1 : 8|8@1+ (1,0) [0|1] ""  FoxESS_battery
+ SG_ reg_B2 : 16|8@1+ (1,0) [0|1] ""  FoxESS_battery
+ SG_ reg_B3 : 24|8@1+ (1,0) [0|1] ""  FoxESS_battery
+ SG_ reg_B4 : 32|8@1+ (1,0) [0|1] ""  FoxESS_battery
+ SG_ reg_B5 : 40|8@1+ (1,0) [0|1] ""  FoxESS_battery
+ SG_ reg_B6 : 48|8@1+ (1,0) [0|1] ""  FoxESS_battery
+ SG_ reg_B7 : 56|8@1+ (1,0) [0|1] ""  FoxESS_battery
+
+
+
+BA_DEF_ BO_  "GenMsgBackgroundColor" STRING ;
+BA_DEF_ BO_  "GenMsgForegroundColor" STRING ;
+BA_DEF_ BO_  "labelfilters" INT 0 0;
+BA_DEF_ BO_  "matchingcriteria" INT 0 0;
+BA_DEF_DEF_  "GenMsgBackgroundColor" "#1e1e1e";
+BA_DEF_DEF_  "GenMsgForegroundColor" "#ffffff";
+BA_DEF_DEF_  "labelfilters" 1;
+BA_DEF_DEF_  "matchingcriteria" 0;
+VAL_ 2147489921 reg_B1 48 "0" 49 "1" 50 "2" 51 "3" 52 "4" 53 "5" 54 "6" 55 "7" 56 "8" 57 "9" 65 "A" 66 "B" 67 "C" 68 "D" 69 "E" 70 "F" 71 "G" 72 "H" 73 "I" 74 "J" 75 "K" 76 "L" 77 "M" 78 "N" 79 "O" 80 "P" 81 "Q" 82 "R" 83 "S" 84 "T" 85 "U" 86 "V" 87 "W" 88 "X" 89 "Y" 90 "Z" ;
+VAL_ 2147489921 reg_B2 48 "0" 49 "1" 50 "2" 51 "3" 52 "4" 53 "5" 54 "6" 55 "7" 56 "8" 57 "9" 65 "A" 66 "B" 67 "C" 68 "D" 69 "E" 70 "F" 71 "G" 72 "H" 73 "I" 74 "J" 75 "K" 76 "L" 77 "M" 78 "N" 79 "O" 80 "P" 81 "Q" 82 "R" 83 "S" 84 "T" 85 "U" 86 "V" 87 "W" 88 "X" 89 "Y" 90 "Z" ;
+VAL_ 2147489921 reg_B3 48 "0" 49 "1" 50 "2" 51 "3" 52 "4" 53 "5" 54 "6" 55 "7" 56 "8" 57 "9" 65 "A" 66 "B" 67 "C" 68 "D" 69 "E" 70 "F" 71 "G" 72 "H" 73 "I" 74 "J" 75 "K" 76 "L" 77 "M" 78 "N" 79 "O" 80 "P" 81 "Q" 82 "R" 83 "S" 84 "T" 85 "U" 86 "V" 87 "W" 88 "X" 89 "Y" 90 "Z" ;
+VAL_ 2147489921 reg_B4 48 "0" 49 "1" 50 "2" 51 "3" 52 "4" 53 "5" 54 "6" 55 "7" 56 "8" 57 "9" 65 "A" 66 "B" 67 "C" 68 "D" 69 "E" 70 "F" 71 "G" 72 "H" 73 "I" 74 "J" 75 "K" 76 "L" 77 "M" 78 "N" 79 "O" 80 "P" 81 "Q" 82 "R" 83 "S" 84 "T" 85 "U" 86 "V" 87 "W" 88 "X" 89 "Y" 90 "Z" ;
+VAL_ 2147489921 reg_B5 48 "0" 49 "1" 50 "2" 51 "3" 52 "4" 53 "5" 54 "6" 55 "7" 56 "8" 57 "9" 65 "A" 66 "B" 67 "C" 68 "D" 69 "E" 70 "F" 71 "G" 72 "H" 73 "I" 74 "J" 75 "K" 76 "L" 77 "M" 78 "N" 79 "O" 80 "P" 81 "Q" 82 "R" 83 "S" 84 "T" 85 "U" 86 "V" 87 "W" 88 "X" 89 "Y" 90 "Z" ;
+VAL_ 2147489921 reg_B6 48 "0" 49 "1" 50 "2" 51 "3" 52 "4" 53 "5" 54 "6" 55 "7" 56 "8" 57 "9" 65 "A" 66 "B" 67 "C" 68 "D" 69 "E" 70 "F" 71 "G" 72 "H" 73 "I" 74 "J" 75 "K" 76 "L" 77 "M" 78 "N" 79 "O" 80 "P" 81 "Q" 82 "R" 83 "S" 84 "T" 85 "U" 86 "V" 87 "W" 88 "X" 89 "Y" 90 "Z" ;
+VAL_ 2147489921 reg_B7 48 "0" 49 "1" 50 "2" 51 "3" 52 "4" 53 "5" 54 "6" 55 "7" 56 "8" 57 "9" 65 "A" 66 "B" 67 "C" 68 "D" 69 "E" 70 "F" 71 "G" 72 "H" 73 "I" 74 "J" 75 "K" 76 "L" 77 "M" 78 "N" 79 "O" 80 "P" 81 "Q" 82 "R" 83 "S" 84 "T" 85 "U" 86 "V" 87 "W" 88 "X" 89 "Y" 90 "Z" ;
+VAL_ 2147489922 reg_B1 48 "0" 49 "1" 50 "2" 51 "3" 52 "4" 53 "5" 54 "6" 55 "7" 56 "8" 57 "9" 65 "A" 66 "B" 67 "C" 68 "D" 69 "E" 70 "F" 71 "G" 72 "H" 73 "I" 74 "J" 75 "K" 76 "L" 77 "M" 78 "N" 79 "O" 80 "P" 81 "Q" 82 "R" 83 "S" 84 "T" 85 "U" 86 "V" 87 "W" 88 "X" 89 "Y" 90 "Z" ;
+VAL_ 2147489922 reg_B2 48 "0" 49 "1" 50 "2" 51 "3" 52 "4" 53 "5" 54 "6" 55 "7" 56 "8" 57 "9" 65 "A" 66 "B" 67 "C" 68 "D" 69 "E" 70 "F" 71 "G" 72 "H" 73 "I" 74 "J" 75 "K" 76 "L" 77 "M" 78 "N" 79 "O" 80 "P" 81 "Q" 82 "R" 83 "S" 84 "T" 85 "U" 86 "V" 87 "W" 88 "X" 89 "Y" 90 "Z" ;
+VAL_ 2147489922 reg_B3 48 "0" 49 "1" 50 "2" 51 "3" 52 "4" 53 "5" 54 "6" 55 "7" 56 "8" 57 "9" 65 "A" 66 "B" 67 "C" 68 "D" 69 "E" 70 "F" 71 "G" 72 "H" 73 "I" 74 "J" 75 "K" 76 "L" 77 "M" 78 "N" 79 "O" 80 "P" 81 "Q" 82 "R" 83 "S" 84 "T" 85 "U" 86 "V" 87 "W" 88 "X" 89 "Y" 90 "Z" ;
+VAL_ 2147489922 reg_B4 48 "0" 49 "1" 50 "2" 51 "3" 52 "4" 53 "5" 54 "6" 55 "7" 56 "8" 57 "9" 65 "A" 66 "B" 67 "C" 68 "D" 69 "E" 70 "F" 71 "G" 72 "H" 73 "I" 74 "J" 75 "K" 76 "L" 77 "M" 78 "N" 79 "O" 80 "P" 81 "Q" 82 "R" 83 "S" 84 "T" 85 "U" 86 "V" 87 "W" 88 "X" 89 "Y" 90 "Z" ;
+VAL_ 2147489922 reg_B5 48 "0" 49 "1" 50 "2" 51 "3" 52 "4" 53 "5" 54 "6" 55 "7" 56 "8" 57 "9" 65 "A" 66 "B" 67 "C" 68 "D" 69 "E" 70 "F" 71 "G" 72 "H" 73 "I" 74 "J" 75 "K" 76 "L" 77 "M" 78 "N" 79 "O" 80 "P" 81 "Q" 82 "R" 83 "S" 84 "T" 85 "U" 86 "V" 87 "W" 88 "X" 89 "Y" 90 "Z" ;
+VAL_ 2147489922 reg_B6 48 "0" 49 "1" 50 "2" 51 "3" 52 "4" 53 "5" 54 "6" 55 "7" 56 "8" 57 "9" 65 "A" 66 "B" 67 "C" 68 "D" 69 "E" 70 "F" 71 "G" 72 "H" 73 "I" 74 "J" 75 "K" 76 "L" 77 "M" 78 "N" 79 "O" 80 "P" 81 "Q" 82 "R" 83 "S" 84 "T" 85 "U" 86 "V" 87 "W" 88 "X" 89 "Y" 90 "Z" ;
+VAL_ 2147489922 reg_B7 48 "0" 49 "1" 50 "2" 51 "3" 52 "4" 53 "5" 54 "6" 55 "7" 56 "8" 57 "9" 65 "A" 66 "B" 67 "C" 68 "D" 69 "E" 70 "F" 71 "G" 72 "H" 73 "I" 74 "J" 75 "K" 76 "L" 77 "M" 78 "N" 79 "O" 80 "P" 81 "Q" 82 "R" 83 "S" 84 "T" 85 "U" 86 "V" 87 "W" 88 "X" 89 "Y" 90 "Z" ;
+VAL_ 2147489923 reg_B1 48 "0" 49 "1" 50 "2" 51 "3" 52 "4" 53 "5" 54 "6" 55 "7" 56 "8" 57 "9" 65 "A" 66 "B" 67 "C" 68 "D" 69 "E" 70 "F" 71 "G" 72 "H" 73 "I" 74 "J" 75 "K" 76 "L" 77 "M" 78 "N" 79 "O" 80 "P" 81 "Q" 82 "R" 83 "S" 84 "T" 85 "U" 86 "V" 87 "W" 88 "X" 89 "Y" 90 "Z" ;
+VAL_ 2147489923 reg_B2 48 "0" 49 "1" 50 "2" 51 "3" 52 "4" 53 "5" 54 "6" 55 "7" 56 "8" 57 "9" 65 "A" 66 "B" 67 "C" 68 "D" 69 "E" 70 "F" 71 "G" 72 "H" 73 "I" 74 "J" 75 "K" 76 "L" 77 "M" 78 "N" 79 "O" 80 "P" 81 "Q" 82 "R" 83 "S" 84 "T" 85 "U" 86 "V" 87 "W" 88 "X" 89 "Y" 90 "Z" ;
+VAL_ 2147489923 reg_B3 48 "0" 49 "1" 50 "2" 51 "3" 52 "4" 53 "5" 54 "6" 55 "7" 56 "8" 57 "9" 65 "A" 66 "B" 67 "C" 68 "D" 69 "E" 70 "F" 71 "G" 72 "H" 73 "I" 74 "J" 75 "K" 76 "L" 77 "M" 78 "N" 79 "O" 80 "P" 81 "Q" 82 "R" 83 "S" 84 "T" 85 "U" 86 "V" 87 "W" 88 "X" 89 "Y" 90 "Z" ;
+VAL_ 2147489923 reg_B4 48 "0" 49 "1" 50 "2" 51 "3" 52 "4" 53 "5" 54 "6" 55 "7" 56 "8" 57 "9" 65 "A" 66 "B" 67 "C" 68 "D" 69 "E" 70 "F" 71 "G" 72 "H" 73 "I" 74 "J" 75 "K" 76 "L" 77 "M" 78 "N" 79 "O" 80 "P" 81 "Q" 82 "R" 83 "S" 84 "T" 85 "U" 86 "V" 87 "W" 88 "X" 89 "Y" 90 "Z" ;
+VAL_ 2147489923 reg_B5 48 "0" 49 "1" 50 "2" 51 "3" 52 "4" 53 "5" 54 "6" 55 "7" 56 "8" 57 "9" 65 "A" 66 "B" 67 "C" 68 "D" 69 "E" 70 "F" 71 "G" 72 "H" 73 "I" 74 "J" 75 "K" 76 "L" 77 "M" 78 "N" 79 "O" 80 "P" 81 "Q" 82 "R" 83 "S" 84 "T" 85 "U" 86 "V" 87 "W" 88 "X" 89 "Y" 90 "Z" ;
+VAL_ 2147489923 reg_B6 48 "0" 49 "1" 50 "2" 51 "3" 52 "4" 53 "5" 54 "6" 55 "7" 56 "8" 57 "9" 65 "A" 66 "B" 67 "C" 68 "D" 69 "E" 70 "F" 71 "G" 72 "H" 73 "I" 74 "J" 75 "K" 76 "L" 77 "M" 78 "N" 79 "O" 80 "P" 81 "Q" 82 "R" 83 "S" 84 "T" 85 "U" 86 "V" 87 "W" 88 "X" 89 "Y" 90 "Z" ;
+VAL_ 2147489923 reg_B7 48 "0" 49 "1" 50 "2" 51 "3" 52 "4" 53 "5" 54 "6" 55 "7" 56 "8" 57 "9" 65 "A" 66 "B" 67 "C" 68 "D" 69 "E" 70 "F" 71 "G" 72 "H" 73 "I" 74 "J" 75 "K" 76 "L" 77 "M" 78 "N" 79 "O" 80 "P" 81 "Q" 82 "R" 83 "S" 84 "T" 85 "U" 86 "V" 87 "W" 88 "X" 89 "Y" 90 "Z" ;
 


### PR DESCRIPTION
### What
This PR improves the DBC file

### Why
Easier to use the DBC file

### How
We set frame format to Extended for all messages.
Added new TX node, FoxESS_battery, and FoxESS_inverter. The messages are now tied to the correct TX node
Renamed the first few cellvoltage messages to match the rest of the messages